### PR TITLE
Added authorize_with_ssl_client

### DIFF
--- a/lib/smart_proxy_salt/salt_api.rb
+++ b/lib/smart_proxy_salt/salt_api.rb
@@ -6,6 +6,7 @@ module Proxy::Salt
   class Api < ::Sinatra::Base
     include ::Proxy::Log
     helpers ::Proxy::Helpers
+    authorize_with_ssl_client
 
     post '/autosign/:host' do
       content_type :json

--- a/lib/smart_proxy_salt/version.rb
+++ b/lib/smart_proxy_salt/version.rb
@@ -1,5 +1,5 @@
 module Proxy
   module Salt
-    VERSION = '1.0.0'
+    VERSION = '2.0.0'
   end
 end


### PR DESCRIPTION
We have refactored develop proxy and extracted the SSL client cert handling
code. Please review. This is needed only if this plugin uses SSL client
certification verification. If not, please close it.