### PR TITLE
Convert the salt runtime duration from milliseconds to seconds

### DIFF
--- a/sbin/upload-salt-reports
+++ b/sbin/upload-salt-reports
@@ -108,6 +108,17 @@ def upload(jobs):
         if job['job']['result'] == {}:
             continue
 
+        # Convert duration to seconds to conform with Puppet run
+        # duration, and in turn, the run time on Foreman reports
+
+        for node, states in job['job']['result'].iteritems():
+            if isinstance(states, dict):
+                for state, params in states.iteritems():
+                    for key, value in params.iteritems():
+                        if key == 'duration':
+                            value = value / 1000
+                            job['job']['result'][node][state][key] = value
+
         connection.request('POST', '/salt/api/v2/jobs/upload',
                 json.dumps(job), headers)
         response = connection.getresponse()

--- a/sbin/upload-salt-reports
+++ b/sbin/upload-salt-reports
@@ -115,7 +115,7 @@ def upload(jobs):
             if isinstance(states, dict):
                 for state, params in states.iteritems():
                     for key, value in params.iteritems():
-                        if key == 'duration':
+                        if key == 'duration' and isinstance(value, float):
                             value = value / 1000
                             job['job']['result'][node][state][key] = value
 


### PR DESCRIPTION
Currently, there is an inconsistency in runtime units on Foreman reports. As far as I can tell, Foreman is expecting the runtime to be in _seconds_, while Salt reports runtime in _milliseconds_.

I've modified `upload-salt-reports` so that it reports the runtime ('duration') in seconds, instead of milliseconds.