### PR TITLE
State apply arguments

### DIFF
--- a/lib/smart_proxy_salt/cli.rb
+++ b/lib/smart_proxy_salt/cli.rb
@@ -57,9 +57,11 @@ module Proxy::Salt::CLI
       }
     end
 
-    def highstate(host)
+    def state_apply(host, opts = {})
       find_salt_binaries
-      cmd = [@sudo, '-u', Proxy::Salt::Plugin.settings.salt_command_user, @salt, '--async', escape_for_shell(host), 'state.highstate']
+      states = opts.delete("states")
+      args = opts.map { |k,v| "#{k}=#{v}" }
+      cmd = [@sudo, '-u', Proxy::Salt::Plugin.settings.salt_command_user, @salt, '--async', escape_for_shell(host), 'state.apply', args.join(' '), states.join(', ')]
       logger.info "Will run state.highstate for #{host}. Full command: #{cmd.join(' ')}"
       shell_command(cmd)
     end

--- a/lib/smart_proxy_salt/salt_api.rb
+++ b/lib/smart_proxy_salt/salt_api.rb
@@ -59,7 +59,7 @@ module Proxy::Salt
     post '/highstate/:host' do
       content_type :json
       begin
-        log_halt 500, "Failed salt run for #{params[:host]}: Check Log files" unless (result = Proxy::Salt.highstate(params[:host]))
+        log_halt 500, "Failed salt run for #{params[:host]}: Check Log files" unless (result = Proxy::Salt.highstate(params[:host], JSON.parse(request.body.read)))
         result
       rescue => e
         log_halt 406, "Failed salt run for #{params[:host]}: #{e}"

--- a/lib/smart_proxy_salt/salt_api.rb
+++ b/lib/smart_proxy_salt/salt_api.rb
@@ -59,7 +59,7 @@ module Proxy::Salt
     post '/highstate/:host' do
       content_type :json
       begin
-        log_halt 500, "Failed salt run for #{params[:host]}: Check Log files" unless (result = Proxy::Salt.highstate(params[:host], JSON.parse(request.body.read)))
+        log_halt 500, "Failed salt run for #{params[:host]}: Check Log files" unless (result = Proxy::Salt.state_apply(params[:host], JSON.parse(request.body.read)))
         result
       rescue => e
         log_halt 406, "Failed salt run for #{params[:host]}: #{e}"

--- a/sbin/upload-salt-reports
+++ b/sbin/upload-salt-reports
@@ -82,7 +82,7 @@ def jobs_to_upload():
     last_uploaded = read_last_uploaded()
 
     job_ids = [id for (id, value) in jobs.iteritems()
-            if value['Function'] == 'state.highstate' and
+            if value['Function'] in ('state.highstate', 'state.apply') and
             int(id) > last_uploaded]
 
     jobs = dict([(job, get_job(job)) for job in job_ids])


### PR DESCRIPTION
This is smart-proxy counterpart for https://github.com/theforeman/foreman_salt/pull/62
Besides parsing and adding arguments to salt command the `state.highstate` was replaced with `state.apply` as the latter is more general (please refer to: [salt doc](https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.state.html#salt.modules.state.apply))
