### PR TITLE
Fix for using password based Foreman authentication

### DIFF
--- a/bin/foreman-node
+++ b/bin/foreman-node
@@ -172,7 +172,7 @@ def enc(minion)
       http.cert = OpenSSL::X509::Certificate.new(File.read(SETTINGS[:ssl_cert]))
       http.key  = OpenSSL::PKey::RSA.new(File.read(SETTINGS[:ssl_key]), nil)
     end
-  elsif SETTINGS[:username] && SETTING[:password]
+  elsif SETTINGS[:username] && SETTINGS[:password]
     req.basic_auth(SETTINGS[:username], SETTINGS[:password])
   end
 


### PR DESCRIPTION
When using password based auth against Foreman for `foreman-node`, I was getting the following error:

`Couldn't retrieve ENC data: uninitialized constant SETTING`

This was fixed by correcting a typo in the variable name `SETTINGS[:password]` in `foreman-node`.
