### PR TITLE
change SALT_MASTER_CONFIG to /etc/salt/master

### DIFF
--- a/bin/foreman-node
+++ b/bin/foreman-node
@@ -72,7 +72,7 @@ import salt.runner
 
 if __name__ == '__main__':
     __opts__ = salt.config.master_config(
-            os.environ.get('SALT_MASTER_CONFIG', '/etc/salt/minion'))
+            os.environ.get('SALT_MASTER_CONFIG', '/etc/salt/master'))
     runner = salt.runner.Runner(__opts__)  
    
     stdout_bak = sys.stdout


### PR DESCRIPTION
With SALT_MASTER_CONFIG being set to /etc/salt/minion we're unable to import grains into TheForeman. Chaning it to /etc/salt/master fixes this.

```
$ diff -ruN grains_orig.py grains_new.py
--- grains_orig.py	2018-03-16 12:08:55.497540661 +0100
+++ grains_new.py	2018-03-16 12:03:00.150365538 +0100
@@ -8,7 +8,7 @@

 if __name__ == '__main__':
     __opts__ = salt.config.master_config(
-            os.environ.get('SALT_MASTER_CONFIG', '/etc/salt/minion'))
+            os.environ.get('SALT_MASTER_CONFIG', '/etc/salt/master'))
     runner = salt.runner.Runner(__opts__)

     stdout_bak = sys.stdout

# root @ foreman.local in ~ [12:09:39] C:1
$ python grains_orig.py
{"xxxx.local": {}}

# root @ foreman.local in ~ [12:09:47]
$ python grains_new.py
{"xxxx.local": {"biosversion": "6.00", "kernel": "Linux", "domain": "local", "uid": 0, "zmqversion": "4.2.1", "kernelr
```