### PR TITLE
Correct the gemspec

### DIFF
--- a/smart_proxy_salt.gemspec
+++ b/smart_proxy_salt.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |s|
   s.files            = Dir['{bin,cron,etc,lib,sbin,settings.d,bundler.d}/**/*'] + s.extra_rdoc_files
   s.executables      = s.files.grep(%r{^bin/}) { |file| File.basename(file) }
   s.homepage         = 'https://github.com/theforeman/smart_proxy_salt'
-  s.license          = 'GPLv3'
+  s.license          = 'GPL-3.0'
 end


### PR DESCRIPTION
License codes should be in SPDX 2.0 format for gem build