### PR TITLE
Allow third party cert on foreman web interface

### DIFF
--- a/sbin/upload-salt-reports
+++ b/sbin/upload-salt-reports
@@ -107,10 +107,11 @@ def upload(jobs):
     else:
         connection = httplib.HTTPConnection(config[':host'],
                 port=config[':port'])
-        if ':username' in config and ':password' in config:
-            token = base64.b64encode('{}:{}'.format(config[':username'],
-                                                    config[':password']))
-            headers['Authorization'] = 'Basic {}'.format(token)
+
+    if ':username' in config and ':password' in config:
+        token = base64.b64encode('{}:{}'.format(config[':username'],
+                                                config[':password']))
+        headers['Authorization'] = 'Basic {}'.format(token)
 
     for job_id, job in jobs:
 

--- a/sbin/upload-salt-reports
+++ b/sbin/upload-salt-reports
@@ -97,7 +97,9 @@ def upload(jobs):
 
     if config[':proto'] == 'https':
         ctx = ssl.create_default_context()
-        ctx.load_cert_chain(certfile=config[':ssl_cert'], keyfile=config[':ssl_key'])
+        if config[':ssl_cert'] and config[':ssl_key']:
+            ctx.load_cert_chain(certfile=config[':ssl_cert'],
+                                keyfile=config[':ssl_key'])
         if config[':ssl_ca']:
           ctx.load_verify_locations(cafile=config[':ssl_ca'])
         connection = httplib.HTTPSConnection(config[':host'],


### PR DESCRIPTION
For environments that do not use puppet, foreman may be secured with a third party certificate. In this scenario a client certificate won't be available but authentication upload-salt-reports can be provided via basic auth.