### PR TITLE
Disregard secondary ip addresses so interfaces in foreman aren't upda…

### DIFF
--- a/bin/foreman-node
+++ b/bin/foreman-node
@@ -93,6 +93,9 @@ EOF
   grains = JSON.load(result)
 
   if grains
+    grains[minion]['ip_interfaces'].each do |key, value|
+      grains[minion]['ip_interfaces'][key] = grains[minion]['ip_interfaces'][key][0]
+    end
     plainify(grains[minion]).flatten.inject(&:merge)
   else
     raise 'No grains received from Salt master'


### PR DESCRIPTION
Salt grains make no segregation between primary and secondary ip addresses. But instead it gives a list ordered as being seen by `ip addr show dev <device>`. 
Index 0 is always the primary IP address and the rest are secondary addresses.

Secondary addresses in linux can have aliases but are disregarded in salt. Also are network aliases obsolete: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Documentation/networking/alias.txt?h=linux-4.18.y 

This pull request makes sure that interfaces in foreman are always updated with their primary IP address instead of the last added secondary address. (Which in our case is problematic in combination with ucarp).