### PR TITLE
Use job.keys() when collecting job IDs

### DIFF
--- a/sbin/upload-salt-reports
+++ b/sbin/upload-salt-reports
@@ -89,8 +89,7 @@ def jobs_to_upload():
     })
     last_uploaded = read_last_uploaded()
 
-    job_ids = [jid for (jid, value) in jobs.items()
-               if int(jid) > last_uploaded]
+    job_ids = [jid for jid in jobs.keys() if int(jid) > last_uploaded]
 
     for job_id in sorted(job_ids):
         yield job_id, get_job(job_id)


### PR DESCRIPTION
The value is unused, so there's no need to use .items() and ignore it.