### PR TITLE
use -l quiet in foreman node

### DIFF
--- a/bin/foreman-node
+++ b/bin/foreman-node
@@ -61,7 +61,7 @@ def plain_grains(minion)
   # We have to get the grains from the cache, because the client
   # is probably running 'state.highstate' right now.
 
-  result = IO.popen(['salt-run', '--output=json', 'cache.grains', minion]) do |io|
+  result = IO.popen(['salt-run', '-l', 'quiet', '--output=json', 'cache.grains', minion]) do |io|
     io.read
   end
 


### PR DESCRIPTION
This makes foreman-node use "-l quiet" when getting the grains, otherwise it may output salt debug messages when configured on the master and produce non-parsable yaml