### PR TITLE
add option to retrieve cache from files instead of using salt-run

### DIFF
--- a/bin/foreman-node
+++ b/bin/foreman-node
@@ -15,6 +15,10 @@ require 'net/https'
 require 'etc'
 require 'timeout'
 
+if SETTINGS[:filecache]
+  require 'msgpack'
+end
+
 begin
   require 'json'
 rescue LoadError
@@ -57,19 +61,40 @@ rescue Exception => e
   exit 1
 end
 
-def plain_grains(minion)
-  # We have to get the grains from the cache, because the client
-  # is probably running 'state.highstate' right now.
+def get_grains_from_filecache(minion)
+  # Use the grains from the salt master's filesystem based cache
+  # This requires the following settings in /etc/salt/foreman.yaml:
+  # :filecache: true
+  # :cachedir: "/path/to/master/cache" (default: "/var/cache/salt/master")
+  # Also, the msgpack rubygem needs to be present
+  cachedir = SETTINGS[:cachedir] || "/var/cache/salt/master"
+  content = File.read("#{cachedir}/minions/#{minion}/data.p")
+  data = MessagePack.unpack(content)
+  data["grains"]
+end
 
+def get_grains_from_saltrun(minion)
   result = IO.popen(['salt-run', '-l', 'quiet', '--output=json', 'cache.grains', minion]) do |io|
     io.read
   end
 
-  grains = JSON.parse(result)
+  data = JSON.parse(result)
+  data[minion]
+end
+
+def plain_grains(minion)
+  # We have to get the grains from the cache, because the client
+  # is probably running 'state.highstate' right now.
+
+  if SETTINGS[:filecache]
+    grains = get_grains_from_filecache(minion)
+  else
+    grains = get_grains_from_saltrun(minion)
+  end
 
   raise 'No grains received from Salt master' unless grains
 
-  plainify(grains[minion]).flatten.inject(&:merge)
+  plainify(grains).flatten.inject(&:merge)
 end
 
 def plainify(hash, prefix = nil)


### PR DESCRIPTION
This adds an option "filecache". 
If set to true, foreman-node will no longer use salt-run to retrieve the cache but directly deserialize the data from the files in /var/cache/salt/master/minions
We are running foreman-salt in a relatively large deployment, with 1500 minions on the largest proxy. When scaling up the saltmaster to more than 20 threads foreman-node will fail to retrieve the grains and return the ENC data and blocks salt processes. 

Comparision:

When getting grains from cache using salt-run:
`# time scl enable rh-ruby25 tfm -- foreman-node <host>`
`[output stripped...]`
`real    0m7.033s`
`user    0m6.073s`
`sys     0m0.430s`

When using filecache:
`# time scl enable rh-ruby25 tfm ./foreman-node2 <host>`
`[output stripped...]`
`real    0m0.780s`
`user    0m0.236s`
`sys     0m0.056s`

This has been tested and is working fine on multiple nodes.
We'd love to get the changes upstream rather than working with a self-patched version in our environment :)
Thanks