### PR TITLE
Drop redundant dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,25 +7,3 @@ gemspec :name => 'smart_proxy_salt_core'
 group :development do
   gem 'smart_proxy', :git => 'https://github.com/theforeman/smart-proxy', :branch => 'develop'
 end
-
-group :test do
-  gem 'webmock'
-  if RUBY_VERSION < '2.1'
-    gem 'public_suffix', '< 3'
-  else
-    gem 'public_suffix'
-  end
-  if RUBY_VERSION < '2.2'
-    gem 'rack-test', '< 0.8'
-  else
-    gem 'rack-test'
-  end
-end
-
-if RUBY_VERSION < '2.2'
-  gem 'rack', '>= 1.1', '< 2.0.0'
-  gem 'sinatra', '< 2'
-else
-  gem 'rack', '>= 1.1'
-  gem 'sinatra'
-end


### PR DESCRIPTION
All the version pinning can be dropped since Smart Proxy now only supports Ruby ~> 2.5. All listed dependencies are already marked as development dependencies or indirect dependencies.