### PR TITLE
decodestring is deprecated since python3.1 and expects a type-like ob…

### DIFF
--- a/salt/report_upload/srv/salt/_runners/foreman_report_upload.py
+++ b/salt/report_upload/srv/salt/_runners/foreman_report_upload.py
@@ -99,7 +99,7 @@ def now(highstate):
     log.debug('Upload highstate to Foreman')
 
     try:
-        report = create_report(base64.decodestring(highstate))
+        report = create_report(base64.b64decode(highstate))
         upload(report)
     except Exception as exc:
         log.error('Exception encountered: %s', exc)


### PR DESCRIPTION
…ject

use base64.b64decode instead