### PR TITLE
fix saltlint complain about missing spaces

### DIFF
--- a/salt/report_upload/srv/salt/foreman_report_upload.sls
+++ b/salt/report_upload/srv/salt/foreman_report_upload.sls
@@ -6,5 +6,5 @@
  foreman_report_upload:
   runner.foreman_report_upload.now:
     - args:
-      - highstate: '{{data|json|base64_encode}}'
+      - highstate: '{{ data|json|base64_encode }}'
 {% endif %}


### PR DESCRIPTION
This is purely cosmetic, it works as is, but saltlint in our pipeline complains about missing spaces:
```
Salt syntax/style errors:
[Pipeline] echo
[206] Jinja variables should have spaces before and after: {{ var_name }}
saltstates/reactor/foreman_report_upload.sls:9
      - highstate: '{{data|json|base64_encode}}'
```