### PR TITLE
Use foreman prov serial

### DIFF
--- a/lib/smart_proxy_salt/salt.rb
+++ b/lib/smart_proxy_salt/salt.rb
@@ -13,6 +13,7 @@ module Proxy
       plugin 'salt', Proxy::Salt::VERSION
 
       default_settings :autosign_file      => '/etc/salt/autosign.conf',
+                       :autosign_key_file  => '/var/lib/foreman-proxy/salt/grains/autosign_key',
                        :salt_command_user  => 'root',
                        :use_api            => false
 

--- a/lib/smart_proxy_salt/salt_api.rb
+++ b/lib/smart_proxy_salt/salt_api.rb
@@ -11,10 +11,30 @@ module Proxy
       helpers ::Proxy::Helpers
       authorize_with_trusted_hosts
 
+      post '/autosign_key/:key' do
+        content_type :json
+        begin
+          Proxy::Salt.autosign_create_key(params[:key]).to_json
+        rescue Exception => e
+          log_halt 406, "Failed to create autosign key #{params[:key]}: #{e}"
+        end
+      end
+
+      delete '/autosign_key/:key' do
+        content_type :json
+        begin
+          Proxy::Salt.autosign_remove_key(params[:key]).to_json
+        rescue Proxy::Salt::NotFound => e
+          log_halt 404, e.to_s
+        rescue Exception => e
+          log_halt 406, "Failed to remove autosign key #{params[:key]}: #{e}"
+        end
+      end
+
       post '/autosign/:host' do
         content_type :json
         begin
-          Proxy::Salt.autosign_create(params[:host]).to_json
+          Proxy::Salt.autosign_create_hostname(params[:host]).to_json
         rescue Exception => e
           log_halt 406, "Failed to create autosign for #{params[:host]}: #{e}"
         end
@@ -23,7 +43,7 @@ module Proxy
       delete '/autosign/:host' do
         content_type :json
         begin
-          Proxy::Salt.autosign_remove(params[:host]).to_json
+          Proxy::Salt.autosign_remove_hostname(params[:host]).to_json
         rescue Proxy::Salt::NotFound => e
           log_halt 404, e.to_s
         rescue Exception => e

--- a/salt/minion_auth/README.md
+++ b/salt/minion_auth/README.md
@@ -1,0 +1,48 @@
+# Foreman Salt Minion Authentication
+
+Currently, there are two possibilites to authenticate a newly deployed minion automatically:
+1. Use the _/etc/salt/autosign.conf_ file which stores the hostnames of acceptable hosts.
+2. Use _Salt Autosign Grains_ for a more secure way which relies on a shared secret key.
+
+This README, handles the second option and how to configure it
+
+## Setup
+Add the content of 'master.snippet' to '/etc/salt/master' which configures the grains key file on the master and a reactor. The grains file holds the acceptable keys and will be written by the Smart Proxy when a new minion is deployed. The reactor initiates an interaction with Foreman Salt if a new minion was authenticated successfully.
+In case there is already a reactor configured, you need to adapt it using the options mentioned in 'master.snippet'. The directories given in 'master.snippet' are the default ones. In case you want your files in a different place, you have to change the paths accordingly.
+
+If '/srv/salt' is configured as 'file_roots' in your '/etc/salt/master' config, setup the necessary Salt runners:
+
+```
+/srv/salt/_runners/foreman_file.py
+/srv/salt/_runners/foreman_https.py
+```
+
+Check if the reactor ('foreman_minion_auth.sls') is at the appropriated location:
+
+```
+/var/lib/foreman-proxy/salt/reactors/foreman_minion_auth.sls
+```
+
+After changing the Salt master, restart the salt-master service:
+
+```
+systemctl restart salt-master
+```
+
+After checking the reactor and runners, run the following command to make them available in the Salt environment:
+
+```
+salt-run saltutil.sync_all
+```
+
+## Procedure
+
+1. A new host, configured as Salt minion, is deployed with Foreman Salt.
+2. Foreman Salt generates a unique key for that minion and distributes it via the Provisioning Template to the host and via an API call to the Smart Proxy.
+3. The Smart Proxy makes the key available for the Salt Autosign Grains procedure by adding it to the previously defined file (by default: /var/lib/foreman-proxy/salt/grains/autosign_key).
+4. The Salt minion is started and uses the configured Salt autosign grain for authentication to the Salt master.
+5. The Salt master accepts the minion depending on the key and the corresponding auth reactor is triggered on the Salt master.
+6. The Salt master initiates an API call to Foreman Salt which marks the corresponding host status as	_authenticated_.
+7. Foreman Salt triggers an API call to Smart Proxy Salt which deletes the key from the acceptable keys list of the Salt master (since the minion was authenticated already and shall not be reused).
+
+The minion was authenticated successfully.

--- a/salt/minion_auth/foreman_minion_auth.sls
+++ b/salt/minion_auth/foreman_minion_auth.sls
@@ -1,0 +1,23 @@
+{% if 'act' in data and 'id' in data %}
+{% if data['act'] == 'accept' %}
+{% if salt['saltutil.runner']('foreman_file.check_key', (data['id'], 100)) == True %}
+{%- do salt.log.info('Minion authenticated successfully, starting HTTPS request to delete autosign key.') -%}
+remove_autosign_key_custom_runner:
+  runner.foreman_https.query_cert:
+    - method: PUT
+    - host: or.deploy2.dev.atix
+    - path: /salt/api/v2/salt_autosign_auth?name={{ data['id'] }}
+    - cert: /etc/pki/katello/puppet/puppet_client.crt
+    - key: /etc/pki/katello/puppet/puppet_client.key
+    - port: 443
+# call_foreman_salt_custom_runner:
+#   runner.foreman_https.query_user:
+#     - method: PUT
+#     - host: or.deploy2.dev.atix
+#     - path: /salt/api/v2/salt_autosign_auth?name={{ data['id']  }}
+#     - username: admin
+#     - password: changeme
+#     - port: 443
+{% endif %}
+{% endif %}
+{% endif %}

--- a/salt/minion_auth/master.snippet
+++ b/salt/minion_auth/master.snippet
@@ -1,0 +1,5 @@
+autosign_grains_dir: /var/lib/foreman-proxy/salt/grains
+
+reactor:
+  - 'salt/auth':
+    - /var/lib/foreman-proxy/salt/reactors/react_key_accept.sls

--- a/salt/minion_auth/srv/salt/_runners/foreman_file.py
+++ b/salt/minion_auth/srv/salt/_runners/foreman_file.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import os
+import time
+
+SALT_KEY_PATH = "/etc/salt/pki/master/minions/"
+
+def time_secs(path):
+    stat = os.stat(path)
+    return stat.st_mtime
+
+
+def younger_than_secs(path, seconds):
+
+    now_time = time.time()
+    file_time = time_secs(path)
+    if now_time - file_time <= seconds:
+        return True
+    return False
+
+def check_key(hostname, seconds):
+    return younger_than_secs(SALT_KEY_PATH + hostname, seconds)

--- a/salt/minion_auth/srv/salt/_runners/foreman_https.py
+++ b/salt/minion_auth/srv/salt/_runners/foreman_https.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+from http.client import HTTPSConnection
+import ssl
+import base64
+import json
+
+
+def query_cert(host, path, port, method, cert, key,
+               payload=None, timeout=10):
+
+    headers = {"Accept": "application/json"}
+
+    if payload is not None or method.lower() in ['put', 'post']:
+        headers["Content-Type"] = "application/json"
+
+    ctx = ssl.create_default_context()
+    ctx.load_cert_chain(certfile=cert, keyfile=key)
+
+    connection = HTTPSConnection(host,
+                                 port=port,
+                                 context=ctx,
+                                 timeout=timeout)
+    if payload is None:
+        connection.request(method,
+                           path,
+                           headers=headers)
+    else:
+        payload_json = json.dumps(payload)
+        connection.request(method=method,
+                           url=path,
+                           body=payload_json,
+                           headers=headers)
+    response = connection.getresponse()
+    response_str = response.read().decode('utf-8')
+    print(response_str)
+
+
+def query_user(host, path, port, method, username, password,
+               payload=None, timeout=10):
+
+    auth = "{}:{}".format(username, password)
+    token = base64.b64encode(auth.encode('utf-8')).decode('ascii')
+    headers = {"Authorization": "Basic {}".format(token),
+               "Accept": "application/json"}
+    if payload is not None or method.lower() in ["put", "post"]:
+        headers["Content-Type"] = "application/json"
+
+    ctx = ssl._create_unverified_context()
+    connection = HTTPSConnection(host,
+                                 port=port,
+                                 context=ctx,
+                                 timeout=timeout)
+    if payload is None:
+        connection.request(method=method,
+                           url=path,
+                           headers=headers)
+    else:
+        payload_json = json.dumps(payload)
+        connection.request(method=method,
+                           url=path,
+                           body=payload_json,
+                           headers=headers)
+    response = connection.getresponse()
+    response_str = response.read().decode('utf-8')
+    print(response_str)

--- a/settings.d/salt.yml.example
+++ b/settings.d/salt.yml.example
@@ -1,6 +1,7 @@
 ---
 :enabled: true
 :autosign_file: /etc/salt/autosign.conf
+:autosign_key_file: /var/lib/foreman-proxy/salt/grains/autosign_key
 :salt_command_user: root
 # Some features require using the Salt API - such as listing
 # environments and retrieving state info


### PR DESCRIPTION
Implement [Autosign via Grains](https://docs.saltproject.io/en/latest/topics/tutorials/autoaccept_grains.html) procedure instead of `autosign.conf` for authentication. This PR refers to the following [Foreman Salt PR](https://github.com/theforeman/foreman_salt/pull/136) and [Foreman PR](https://github.com/theforeman/foreman/pull/8489).
* Remove previous `autosign.conf` procedure
* Add new autosign key
  * Set autosign path to `/var/lib/foreman-proxy/salt/grains/autosign_key`
  * Implement API entry to write incoming autosign keys to the autosign_key file
* Remove existing autosign key
  * Add Salt reactor to identify initial authentication of new Salt Minion
  * Add Salt runner to read file age
  * Add Salt runner to enable https requests
  * Make HTTPS Request to foreman when a new Minion authenticated succesfully
  * Provide API entry to remove autosign key from the autosign_key file
