### PR TITLE
Fix foreman-node to use scl

### DIFF
--- a/bin/foreman-node
+++ b/bin/foreman-node
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/tfm-ruby
 # frozen_string_literal: true
 
 # This is the external nodes script to allow Salt to retrieve info about a host


### PR DESCRIPTION
Since SmartProxy now also runs in SCL, the `foreman-node` application needs to use the SCL ruby-version + SCL environment