### PR TITLE
Add python version wrapper

### DIFF
--- a/bin/salt_python_wrapper
+++ b/bin/salt_python_wrapper
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -u
+
+for py in 'python3' 'python'; do
+  exe=$(type -p ${py})
+  if [ -n "${exe}" ]; then
+    if ${exe} -c 'import salt.config'; then
+      ${exe} "$@"
+      exit $?
+    fi
+  fi
+done
+
+echo "No usable python version found, check if python or python3 can import salt.config!" 1>&2
+exit 1

--- a/sbin/upload-salt-reports
+++ b/sbin/upload-salt-reports
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/salt_python_wrapper
 # Uploads reports from the Salt job cache to Foreman
 
 from __future__ import print_function


### PR DESCRIPTION
Determine which python version is used for Salt by checking `python` and `python3` to import `salt.config` .
* Add shell script `salt_python_wrapper` to determine and run python
* Use `salt_python_wrapper` to execute `upload-salt-reports` by default