### PR TITLE
Change API authorization to trusted hosts

### DIFF
--- a/lib/smart_proxy_salt/salt_api.rb
+++ b/lib/smart_proxy_salt/salt_api.rb
@@ -9,7 +9,7 @@ module Proxy
     class Api < ::Sinatra::Base
       include ::Proxy::Log
       helpers ::Proxy::Helpers
-      authorize_with_ssl_client
+      authorize_with_trusted_hosts
 
       post '/autosign/:host' do
         content_type :json


### PR DESCRIPTION
* Permit hosts only with cert to make requests
* In order to make a reuqest, hosts need to be registered as trusted hosts

Compare similar configuration in [OpenSCAP Plugin](https://github.com/theforeman/smart_proxy_openscap/pull/25/files#diff-fbe7d64c50c2c7a03bfaf502ac7a73aa46d3e9c7551802a9a70af18b7d2c5927R5).