### PR TITLE
Add an explicit module dependency on Dynflow

### DIFF
--- a/lib/smart_proxy_salt/salt.rb
+++ b/lib/smart_proxy_salt/salt.rb
@@ -18,6 +18,8 @@ module Proxy
                        :use_api            => false,
                        :saltfile           => '/etc/foreman-proxy/settings.d/salt.saltfile'
 
+      requires :dynflow, '>= 0.5.0'
+
       rackup_path File.expand_path('salt_http_config.ru', __dir__)
 
       load_classes do

--- a/test/integration/root_api_test.rb
+++ b/test/integration/root_api_test.rb
@@ -29,4 +29,17 @@ class SaltApiFeaturesTest < Test::Unit::TestCase
     assert_equal([], mod['capabilities'])
     assert_equal({}, mod['settings'])
   end
+
+  def test_without_dynflow
+    Proxy::LegacyModuleLoader.any_instance.expects(:load_configuration_file).with('dynflow.yml').returns(enabled: false)
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('salt.yml').returns(enabled: true)
+
+    get '/features'
+
+    response = JSON.parse(last_response.body)
+
+    mod = response['salt']
+    refute_nil(mod)
+    assert_equal('failed', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:salt])
+  end
 end


### PR DESCRIPTION
This causes the module itself to fail if dynflow isn't enabled.

Includes https://github.com/theforeman/smart_proxy_salt/pull/67 for the basic integration test.