### PR TITLE
Fix salt runner argument type

### DIFF
--- a/lib/smart_proxy_salt/salt_task_launcher.rb
+++ b/lib/smart_proxy_salt/salt_task_launcher.rb
@@ -13,7 +13,7 @@ module Proxy
           }
           ::Proxy::Salt::SaltRunner.new(
             input.merge(additional_options),
-            :suspended_action => suspended_action
+            suspended_action
           )
         end
       end


### PR DESCRIPTION
_Problem:_ Argument is interpreted as hash
_Fix:_ Pass `suspended_action` as positional argument