### PR TITLE
Integrate foreman.yaml configuration for Autosign runner

### DIFF
--- a/salt/minion_auth/README.md
+++ b/salt/minion_auth/README.md
@@ -17,13 +17,13 @@ If '/srv/salt' is configured as 'file_roots' in your '/etc/salt/master' config, 
 /srv/salt/_runners/foreman_https.py
 ```
 
-Check if the reactor ('foreman_minion_auth.sls') is at the appropriated location and set the correct smart proxy address in the reactor file:
+Check if the reactor ('foreman_minion_auth.sls') is at the appropriated location:
 
 ```
 /var/lib/foreman-proxy/salt/reactors/foreman_minion_auth.sls
 ```
 
-After changing the Salt master, restart the salt-master service:
+Restart the salt-master service:
 
 ```
 systemctl restart salt-master

--- a/salt/minion_auth/foreman_minion_auth.sls
+++ b/salt/minion_auth/foreman_minion_auth.sls
@@ -3,22 +3,8 @@
 {% if salt['saltutil.runner']('foreman_file.check_key', (data['id'], 100)) == True %}
 {%- do salt.log.info('Minion authenticated successfully, starting HTTPS request to delete autosign key.') -%}
 remove_autosign_key_custom_runner:
-  runner.foreman_https.query_cert:
-    - method: PUT
-    - host: example.proxy.com # set smart proxy address
-    - path: /salt/api/v2/salt_autosign_auth?name={{ data['id'] }}
-    - cert: /etc/pki/katello/puppet/puppet_client.crt # default cert location
-    - key: /etc/pki/katello/puppet/puppet_client.key # default key location
-    - port: 443
-# Uncomment the following lines in case you want to use username + password authentication (not recommended)
-# call_foreman_salt_custom_runner:
-#   runner.foreman_https.query_user:
-#     - method: PUT
-#     - host: example.proxy.com # set smart proxy address
-#     - path: /salt/api/v2/salt_autosign_auth?name={{ data['id']  }}
-#     - username: my_username # set username
-#     - password: my_password # set password
-#     - port: 443
+  runner.foreman_https.remove_key:
+    - minion: {{ data['id'] }}
 {% endif %}
 {% endif %}
 {% endif %}

--- a/salt/minion_auth/srv/salt/_runners/foreman_file.py
+++ b/salt/minion_auth/srv/salt/_runners/foreman_file.py
@@ -1,9 +1,12 @@
-#!/usr/bin/env python
+"""
+Salt runner to check the age of a minion key file.
+"""
 
 import os
 import time
 
 SALT_KEY_PATH = "/etc/salt/pki/master/minions/"
+
 
 def time_secs(path):
     stat = os.stat(path)
@@ -17,6 +20,7 @@ def younger_than_secs(path, seconds):
     if now_time - file_time <= seconds:
         return True
     return False
+
 
 def check_key(hostname, seconds):
     return younger_than_secs(SALT_KEY_PATH + hostname, seconds)

--- a/salt/minion_auth/srv/salt/_runners/foreman_https.py
+++ b/salt/minion_auth/srv/salt/_runners/foreman_https.py
@@ -1,13 +1,65 @@
-#!/usr/bin/env python
+"""
+Salt runner to make generic https requests or perform directly
+an autosign key removal.
+"""
+
 
 from http.client import HTTPSConnection
 import ssl
 import base64
 import json
+import logging
+import yaml
+
+FOREMAN_CONFIG = '/etc/salt/foreman.yaml'
+log = logging.getLogger(__name__)
+
+
+def salt_config():
+    """
+    Read the foreman configuratoin from FOREMAN_CONFIG
+    """
+    with open(FOREMAN_CONFIG, 'r') as config_file:
+        config = yaml.load(config_file.read())
+    return config
+
+
+def remove_key(minion):
+    """
+    Perform an HTTPS request to the configured foreman host and trigger
+    the autosign key removal process.
+    """
+    config = salt_config()
+    host_name = config[':host']
+    port = config[':port']
+    timeout = config[':timeout']
+    method = 'PUT'
+    path = '/salt/api/v2/salt_autosign_auth?name=%s' % minion
+
+    # Differentiate between cert and user authentication
+    if config[':proto'] == 'https':
+        query_cert(host=host_name,
+                   path=path,
+                   port=port,
+                   method=method,
+                   cert=config[':ssl_cert'],
+                   key=config[':ssl_key'],
+                   timeout=timeout)
+    else:
+        query_user(host=host_name,
+                   path=path,
+                   port=port,
+                   method=method,
+                   username=config[':username'],
+                   password=config[':password'],
+                   timeout=timeout)
 
 
 def query_cert(host, path, port, method, cert, key,
                payload=None, timeout=10):
+    """
+    Perform an HTTPS query with certificate credentials.
+    """
 
     headers = {"Accept": "application/json"}
 
@@ -38,6 +90,9 @@ def query_cert(host, path, port, method, cert, key,
 
 def query_user(host, path, port, method, username, password,
                payload=None, timeout=10):
+    """
+    Perform an HTTPS query with user credentials.
+    """
 
     auth = "{}:{}".format(username, password)
     token = base64.b64encode(auth.encode('utf-8')).decode('ascii')


### PR DESCRIPTION
## Context

When a new Minion was authenticated successfully to the Master, the `foreman_minion_auth.sls` reactor (see [here](https://github.com/theforeman/smart_proxy_salt/blob/master/salt/minion_auth/foreman_minion_auth.sls)) is called which performs an HTTPS request to the Foreman. Since Salt supports only HTTP requests by default, the custom runner `foreman_https` is used (see [here](https://github.com/theforeman/smart_proxy_salt/blob/master/salt/minion_auth/srv/salt/_runners/foreman_https.py)).

## Current procedure

In the past, the reactor passes request parameters like the path, hostname, and request type to the runner. Therefore, the reactor has to be configured manually (the hostname must configured).

## New procedure

This PR extends the `foreman_https` runner by the `remove_key` function. This function reads the configuration parameters from the existing `/etc/salt/foreman.yaml` configuration file. So, the reactor `foreman_minion_auth.sls` doesn't need to be configured anymore, since the configuration parameters are read from the `foreman.yaml` file.

## Changes
Integrate foreman.yaml configuration for Autosign runner:
* Derive parameters from configuration file
* Add remove_key runner function
* Adapt reactor to call remove_key directly