### PR TITLE
Adapt Salt event content evaluation to new format

### DIFF
--- a/salt/report_upload/srv/salt/_runners/foreman_report_upload.py
+++ b/salt/report_upload/srv/salt/_runners/foreman_report_upload.py
@@ -81,7 +81,7 @@ def create_report(json_str):
                 return {'job':
                      {
                        'result': {
-                         msg['id']: entry['changes']['ret'],
+                         msg['id']: next(iter(entry['changes'].values())),
                        },
                        'function': 'state.highstate',
                        'job_id': msg['jid']


### PR DESCRIPTION
In Salt 3005, a field in the JSON format of the job event changed. Previously, the job data of a successful `stage.highstate` run looked like the following:
```
{
  "cmd": "_return",
  "id": "example.minion.com",
  "success": true,
  "return": {
    "module_|-state.highstate_|-state.highstate_|-run": {
      "name": "state.highstate",
      "changes": {
        "ret": {
          "file_|-/etc/motd_|-/etc/motd_|-managed": {
            "changes": {},
            "comment": "File /etc/motd is in the correct state",
            "name": "/etc/motd",
            "result": true,
            "__sls__": "motd",
            "__run_num__": 0,
            "start_time": "<some time>",
            "duration": <some number>,
            "__id__": "/etc/motd"
...
```

Now, it looks like this:

```
{
  "cmd": "_return",
  "id": "aaar9.testdmz.atix",
  "success": true,
  "return": {
    "module_|-state.highstate_|-state.highstate_|-run": {
      "name": [
        "state.highstate"
      ],
      "changes": {
        "state.highstate": {
          "file_|-/etc/motd_|-/etc/motd_|-managed": {
            "changes": {},
            "comment": "File /etc/motd is in the correct state",
            "name": "/etc/motd",
            "result": true,
            "__sls__": "motd",
            "__run_num__": 0,
            "start_time": "09:19:01.844050",
            "duration": 80.18,
            "__id__": "/etc/motd"
```

The key name of the `changes` part was adapted from `ret` to the actual job id (in this case `state.highstate`). The code change supports both versions since it just takes the first item in the JSON instead of using the actual key name.

Took the code suggestions for dictionary unpacking from [here](https://stackoverflow.com/a/51264229).