### PR TITLE
Add GitHub actions for gem release and linting

### DIFF
--- a/.github/workflows/release_gem.yaml
+++ b/.github/workflows/release_gem.yaml
@@ -1,0 +1,17 @@
+---
+name: Release
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    # Pattern matched against refs/tags
+    tags: ['**']
+
+jobs:
+  release:
+    name: Release gem
+    uses: theforeman/actions/.github/workflows/release-gem.yml@v0
+    with:
+      allowed_owner: theforeman
+    secrets:
+      api_key: ${{ secrets.RUBYGEM_API_KEY }}

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,0 +1,11 @@
+---
+name: Yaml Lint
+# yamllint disable-line rule:truthy
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
+---
 inherit_from: .rubocop_todo.yml
 
 AllCops:


### PR DESCRIPTION
Use the official Foreman GitHub action to release new gems.

Additionally: Add yamllint action. 