### PR TITLE
fix report upload

### DIFF
--- a/salt/minion_auth/srv/salt/_runners/foreman_https.py
+++ b/salt/minion_auth/srv/salt/_runners/foreman_https.py
@@ -20,7 +20,7 @@ def salt_config():
     Read the foreman configuratoin from FOREMAN_CONFIG
     """
     with open(FOREMAN_CONFIG, 'r') as config_file:
-        config = yaml.load(config_file.read())
+        config = yaml.safe_load(config_file.read())
     return config
 
 

--- a/salt/report_upload/srv/salt/_runners/foreman_report_upload.py
+++ b/salt/report_upload/srv/salt/_runners/foreman_report_upload.py
@@ -33,7 +33,7 @@ if sys.version_info.major == 3:
 
 def salt_config():
     with open(FOREMAN_CONFIG, 'r') as f:
-        config = yaml.load(f.read())
+        config = yaml.safe_load(f.read())
     return config
 
 

--- a/sbin/upload-salt-reports
+++ b/sbin/upload-salt-reports
@@ -28,7 +28,7 @@ if sys.version_info.major == 3:
 
 def salt_config():
     with io.open(FOREMAN_CONFIG, 'r') as f:
-        config = yaml.load(f.read())
+        config = yaml.safe_load(f.read())
     return config
 
 


### PR DESCRIPTION
Servus,

yaml.load() is deprecated is newer version of pyyaml 

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

so when using salt in later version the report upload will fail. 

Changing to safe_load fixes this issue (which is recommended anyway)