### PR TITLE
Use the smart_proxy_plugin.yml reusable GHA workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,5 @@ jobs:
   test:
     name: Tests
     needs: rubocop
-    uses: theforeman/actions/.github/workflows/test-gem.yml@v0
-    with:
-      command: bundle exec rake test
+    uses: theforeman/actions/.github/workflows/smart_proxy_plugin.yml@v0
 ...

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'mocha', '~> 1'
   gem 'rack-test'
   gem 'rake', '~> 13'
-  gem 'smart_proxy', github: 'theforeman/smart-proxy', branch: 'develop'
+  gem 'smart_proxy', github: 'theforeman/smart-proxy', branch: ENV.fetch('SMART_PROXY_BRANCH', 'develop')
   gem 'test-unit', '~> 3'
   gem 'webmock', '~> 1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :rubocop do
 end
 
 group :test do
-  gem 'ci_reporter_test_unit'
   gem 'mocha', '~> 1'
   gem 'rack-test'
   gem 'rake', '~> 13'

--- a/Rakefile
+++ b/Rakefile
@@ -29,14 +29,3 @@ RuboCop::RakeTask.new(:rubocop) do |task|
   task.patterns = ['bin/foreman-node', 'lib/**/*.rb', 'test/**/*.rb']
   task.fail_on_error = false
 end
-
-begin
-  require 'ci/reporter/rake/test_unit'
-rescue LoadError
-  # test group not enabled
-else
-  namespace :jenkins do
-    desc nil # No description means it's not listed in rake -T
-    task unit: ['ci:setup:testunit', :test]
-  end
-end

--- a/smart_proxy_salt.gemspec
+++ b/smart_proxy_salt.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files            = Dir['{bin,etc,lib/smart_proxy_salt,salt,sbin,settings.d,bundler.d}/**/*'] + ['lib/smart_proxy_salt.rb'] + s.extra_rdoc_files
   s.executables      = s.files.grep(%r{^bin/}) { |file| File.basename(file) }
   s.homepage         = 'https://github.com/theforeman/smart_proxy_salt'
-  s.license          = 'GPL-3.0'
+  s.license          = 'GPL-3.0-only'
   s.required_ruby_version = '>= 2.7', '< 4'
   s.add_runtime_dependency('smart_proxy_dynflow', '~> 0.5', '>= 0.5.0')
 end

--- a/test/unit/salt_runner_test.rb
+++ b/test/unit/salt_runner_test.rb
@@ -32,9 +32,13 @@ module Proxy
       def test_override_exit_status
         runner = SaltRunner.new({}, :suspended_action => nil)
         assert_nil runner.jid
-        assert_equal 1, runner.publish_exit_status(0)
+        runner.publish_exit_status(0)
+        updates = runner.generate_updates
+        assert_equal 1, updates[{:suspended_action => nil}].exit_status
         runner.publish_data('jid: 12345', 'stdout')
-        assert_equal 0, runner.publish_exit_status(0)
+        runner.publish_exit_status(0)
+        updates = runner.generate_updates
+        assert_equal 0, updates[{:suspended_action => nil}].exit_status
       end
 
       def test_generate_command


### PR DESCRIPTION
This is largely the same as test-gem, except it verifies that it at least implements support for Ruby versions that the Smart Proxy wants. It also implements the version selector by respecting SMART_PROXY_BRANCH in the Gemfile.

It also cleans up the Jenkins integration.