### PR TITLE
Apply rubocop in salt_runner_test

### DIFF
--- a/test/unit/salt_runner_test.rb
+++ b/test/unit/salt_runner_test.rb
@@ -34,11 +34,11 @@ module Proxy
         assert_nil runner.jid
         runner.publish_exit_status(0)
         updates = runner.generate_updates
-        assert_equal 1, updates[{:suspended_action => nil}].exit_status
+        assert_equal 1, updates[{ :suspended_action => nil }].exit_status
         runner.publish_data('jid: 12345', 'stdout')
         runner.publish_exit_status(0)
         updates = runner.generate_updates
-        assert_equal 0, updates[{:suspended_action => nil}].exit_status
+        assert_equal 0, updates[{ :suspended_action => nil }].exit_status
       end
 
       def test_generate_command


### PR DESCRIPTION
Fixes missing space inside brackets.

This was ignored in a previous run: https://github.com/theforeman/smart_proxy_salt/actions/runs/12086309119/job/33705346511

However, I'm not sure why it didn't turn the pipeline red?