### PR TITLE
Revert "Fix tests for Ruby 3.4"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,4 @@ group :test do
   gem 'smart_proxy', github: 'theforeman/smart-proxy', branch: ENV.fetch('SMART_PROXY_BRANCH', 'develop')
   gem 'test-unit', '~> 3'
   gem 'webmock', '~> 1'
-  gem 'csv', '~> 3.0'
 end


### PR DESCRIPTION
This reverts commit 01555ca3f346ae7d50a609ffe8ae667d9749ca9f because Dynflow is now updated for Ruby 3.4 compatibility.